### PR TITLE
Ignore collapsed children

### DIFF
--- a/source/WpfAutoGrid/AutoGrid.cs
+++ b/source/WpfAutoGrid/AutoGrid.cs
@@ -372,7 +372,8 @@
             var skip = new bool[rowCount, colCount];
             foreach (UIElement child in Children)
             {
-                if (IsAutoIndexing)
+                var childIsCollapsed = child.Visibility == Visibility.Collapsed;
+                if (IsAutoIndexing && !childIsCollapsed)
                 {
                     if (fillRowFirst)
                     {


### PR DESCRIPTION
Collapsed children should be ignored when the layout is performed to make sure they don't affect the layout.